### PR TITLE
Remove current_index and add size of blockchain in GET response

### DIFF
--- a/core/bc.go
+++ b/core/bc.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"reflect"
 	"sync"
 	"time"
 
@@ -18,10 +19,10 @@ var (
 // BC a.k.a Blockchain, a simple chain of blocks
 type BC struct {
 	// Chain - Blocks in BC
-	Count        int     `json:"count"`
-	CurrentIndex int     `json:"current_index"`
-	CurrentHash  string  `json:"current_hash"`
-	Chain        []Block `json:"chain"`
+	Count       int     `json:"count"`
+	Size        uintptr `json:"size"`
+	CurrentHash string  `json:"current_hash"`
+	Chain       []Block `json:"chain"`
 }
 
 func getGenesisBlock() Block {
@@ -39,7 +40,7 @@ func Init() {
 		genBlock := getGenesisBlock()
 		blockchain.Chain[0] = genBlock
 		blockchain.Count = len(blockchain.Chain)
-		blockchain.CurrentIndex = genBlock.Index
+		blockchain.Size = uintptr(len(blockchain.Chain)) * reflect.TypeOf(blockchain.Chain).Elem().Size()
 		blockchain.CurrentHash = *genBlock.Hash
 	}
 	mutex.Unlock()
@@ -60,7 +61,7 @@ func Add(data interface{}) (bool, *Block, error) {
 	mutex.Lock()
 	blockchain.Chain = append(blockchain.Chain, *newBlock)
 	blockchain.Count = len(blockchain.Chain)
-	blockchain.CurrentIndex = newBlock.Index
+	blockchain.Size = uintptr(len(blockchain.Chain)) * reflect.TypeOf(blockchain.Chain).Elem().Size()
 	blockchain.CurrentHash = *newBlock.Hash
 	mutex.Unlock()
 	return true, newBlock, nil

--- a/webservice/server.go
+++ b/webservice/server.go
@@ -13,20 +13,41 @@ import (
 	"github.com/heckdevice/gobc/utils"
 )
 
+/**** Server Routes & Port ******/
+var (
+	geturl  = "/gobc"
+	posturl = "/gobc/add"
+)
+
+// FetchGetURL - GET blockchain api relative url
+func FetchGetURL() string {
+	return geturl
+}
+
+// FetchPostURL - POST data to blockchain relative url
+func FetchPostURL() string {
+	return posturl
+}
+
+// GetPort - get Blockchain webservice port
+func GetPort() string {
+	return os.Getenv("PORT")
+}
+
+/****** Muxes and handlers *******/
 func registerMuxes() http.Handler {
 	router := mux.NewRouter()
-	router.HandleFunc("/", handleGetBlockchain).Methods("GET")
-	router.HandleFunc("/", handleWriteBlock).Methods("POST")
+	router.HandleFunc(FetchGetURL(), handleGetBlockchain).Methods("GET")
+	router.HandleFunc(FetchPostURL(), handleWriteBlock).Methods("POST")
 	return router
 }
 
 // Run - start the webservice
 func Run() error {
 	mux := registerMuxes()
-	httpPort := os.Getenv("PORT")
-	log.Println("GoBC Server Listening on port :", httpPort)
+	log.Println("GoBC Server Listening on port :", GetPort())
 	s := &http.Server{
-		Addr:           ":" + httpPort,
+		Addr:           ":" + GetPort(),
 		Handler:        mux,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,


### PR DESCRIPTION
- Expose funcs in webservice to get routes and ports
- Replaced the redundant field current_index, added size of the chain